### PR TITLE
Set Content-Type HTTP header

### DIFF
--- a/src/SendyPHP.php
+++ b/src/SendyPHP.php
@@ -206,7 +206,7 @@ class SendyPHP
         $postdata = http_build_query($content);
 
         $ch = curl_init($this->installation_url .'/'. $type);
-        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/x-www-form-urlencoded"));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
         curl_setopt($ch, CURLOPT_POST, 1);


### PR DESCRIPTION
I was getting a blank response from Sendy until I added the HTTP header of

```
Content-Type: application/x-www-form-urlencoded
```

I've linked this issue with my Sendy forum post at https://sendy.co/forum/messages/2232.
