### PR TITLE
Added CURLOPT_SSL_VERIFYPEER and CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/src/SendyPHP.php
+++ b/src/SendyPHP.php
@@ -207,6 +207,8 @@ class SendyPHP
 
         $ch = curl_init($this->installation_url .'/'. $type);
         curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
         curl_setopt($ch, CURLOPT_POST, 1);


### PR DESCRIPTION
On some server configuration you need this if sendy is hosted and only reachable on a ssl host. Otherwise you just get back a false and an empty message value by SendyPHP.
